### PR TITLE
Update for MediaGoblin >= 0.9.0 with multi-resolution video.

### DIFF
--- a/embedcode/templates/mediagoblin/plugins/embedcode/embed_code.html
+++ b/embedcode/templates/mediagoblin/plugins/embedcode/embed_code.html
@@ -20,9 +20,15 @@
 <p/>
 <div id="embed_code">
   {% if media.media_type == "mediagoblin.media_types.video" %}
-    {% set file_url = request.app.public_store.file_url(media.media_files.webm_video) %}
+    {% if 'webm_video' in media.media_files %}
+      {# MediaGoblin <= 0.9.0 #}
+      {% set file_url = request.app.public_store.file_url(media.media_files.webm_video) %}
+    {% elif 'webm_720p' in media.media_files %}
+      {# MediaGoblin > 0.9.0 with muti-resolution video #}
+      {% set file_url = request.app.public_store.file_url(media.media_files.webm_720p) %}
+    {% endif %}
     {% if '://' not in file_url %}
-      {% set file_url = request.host_url + file_url %}
+      {% set file_url = request.host_url[:-1] + file_url %}
     {% endif %}
     <h3>{% trans %}Embed{% endtrans %}</h3>
     <p>
@@ -39,7 +45,7 @@
   {% if media.media_type == "mediagoblin.media_types.audio" %}
     <h3>{% trans %}Embed{% endtrans %}</h3>
     <p>
-    <pre><code>&lt;audio class="audio-player" controls="controls" preload="metadata"&gt; &lt;source src="{{ request.host_url + request.app.public_store.file_url( media.media_files.webm_audio) }}" type="audio/webm; codecs=vorbis" /&gt; &lt;div class="no_html5"&gt; {%- trans -%}Sorry, this audio will not work because your web browser does not support HTML5 audio.{%- endtrans -%} &lt;/div&gt; &lt;/audio&gt;</code></pre>
+    <pre><code>&lt;audio class="audio-player" controls="controls" preload="metadata"&gt; &lt;source src="{{ request.host_url[:-1] + request.app.public_store.file_url( media.media_files.webm_audio) }}" type="audio/webm; codecs=vorbis" /&gt; &lt;div class="no_html5"&gt; {%- trans -%}Sorry, this audio will not work because your web browser does not support HTML5 audio.{%- endtrans -%} &lt;/div&gt; &lt;/audio&gt;</code></pre>
 {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Also fixes the double-forwardslash in URLs. A more robust approach would be to use `urllib.parse.urljoin`.

This is a little bit of a lash-up, since the administrator could have defined custom resolutions in the configuration.